### PR TITLE
Use the correct beat name on state registry

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -138,6 +138,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Periodic metrics in logs will now report `libbeat.output.events.active` and `beat.memstats.rss`
 - Allows disable pod events enrichment with deployment name {pull}28521[28521]
 - Fix `fingerprint` processor to give it access to the `@timestamp` field. {issue}28683[28683]
+- Fix the wrong beat name on monitoring and state endpoint {issue}27755[27755]
 
 *Auditbeat*
 

--- a/libbeat/cmd/instance/beat.go
+++ b/libbeat/cmd/instance/beat.go
@@ -162,19 +162,14 @@ func Run(settings Settings, bt beat.Creator) error {
 		return errw.Wrap(err, "could not set umask")
 	}
 
-	name := settings.Name
-	idxPrefix := settings.IndexPrefix
-	agentVersion := settings.Version
-	elasticLicensed := settings.ElasticLicensed
-
 	return handleError(func() error {
 		defer func() {
 			if r := recover(); r != nil {
-				logp.NewLogger(name).Fatalw("Failed due to panic.",
+				logp.NewLogger(settings.Name).Fatalw("Failed due to panic.",
 					"panic", r, zap.Stack("stack"))
 			}
 		}()
-		b, err := NewBeat(name, idxPrefix, agentVersion, elasticLicensed)
+		b, err := NewInitializedBeat(settings)
 		if err != nil {
 			return err
 		}
@@ -409,10 +404,6 @@ func (b *Beat) launch(settings Settings, bt beat.Creator) error {
 	defer logp.Sync()
 	defer logp.Info("%s stopped.", b.Info.Beat)
 
-	err := b.InitWithSettings(settings)
-	if err != nil {
-		return err
-	}
 	defer func() {
 		if err := b.processing.Close(); err != nil {
 			logp.Warn("Failed to close global processing: %v", err)
@@ -428,7 +419,7 @@ func (b *Beat) launch(settings Settings, bt beat.Creator) error {
 	// Try to acquire exclusive lock on data path to prevent another beat instance
 	// sharing same data path.
 	bl := newLocker(b)
-	err = bl.lock()
+	err := bl.lock()
 	if err != nil {
 		return err
 	}

--- a/libbeat/cmd/instance/beat_integration_test.go
+++ b/libbeat/cmd/instance/beat_integration_test.go
@@ -1,0 +1,74 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package instance_test
+
+import (
+	"encoding/json"
+	"flag"
+	"net/http"
+	"sync"
+	"testing"
+
+	"github.com/elastic/beats/v7/libbeat/beat"
+	"github.com/elastic/beats/v7/libbeat/cmd/instance"
+	"github.com/elastic/beats/v7/libbeat/common"
+	"github.com/elastic/beats/v7/libbeat/mock"
+)
+
+func TestMonitoringNameFromConfig(t *testing.T) {
+	mockBeat, _ := mock.New(nil, nil)
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+
+	// Make sure the beat has stopped before finishing the test
+	t.Cleanup(wg.Wait)
+
+	go func() {
+		defer wg.Done()
+
+		// Set the configuration file path flag so the beat can read it
+		flag.Set("c", "testdata/mockbeat.yml")
+		instance.Run(mock.Settings, func(_ *beat.Beat, _ *common.Config) (beat.Beater, error) {
+			return mockBeat, nil
+		})
+	}()
+
+	t.Cleanup(func() {
+		mockBeat.Stop()
+	})
+
+	resp, err := http.Get("http://localhost:5066/state")
+	if err != nil {
+		t.Fatal("calling state endpoint: ", err.Error())
+	}
+	defer resp.Body.Close()
+
+	beatName := struct {
+		Beat struct {
+			Name string
+		}
+	}{}
+
+	if err := json.NewDecoder(resp.Body).Decode(&beatName); err != nil {
+		t.Fatalf("could not decode response body: %s", err.Error())
+	}
+
+	if got, want := beatName.Beat.Name, "TestMonitoringNameFromConfig"; got != want {
+		t.Fatalf("expecting '%s', got '%s'", want, got)
+	}
+}

--- a/libbeat/cmd/instance/testdata/mockbeat.yml
+++ b/libbeat/cmd/instance/testdata/mockbeat.yml
@@ -1,0 +1,24 @@
+############################# Mockbeat ######################################
+mockbeat:
+############################# General ############################################
+
+# The name of the shipper that publishes the network data. It can be used to group
+# all the transactions sent by a single shipper in the web interface.
+# If this options is not defined, the hostname is used.
+
+name: TestMonitoringNameFromConfig
+
+# The tags of the shipper are included in their own field with each
+# transaction published. Tags make it easy to group servers by different
+# logical properties.
+# tags: []
+
+############################# Output ############################################
+
+# Configure what outputs to use when sending the data collected by mockbeat.
+# Multiple outputs may NOT be enabled.
+output.elasticsearch:
+    hosts: ["localhost:9200"]
+http:
+  enabled: true
+  port: 5066

--- a/libbeat/mock/mockbeat.go
+++ b/libbeat/mock/mockbeat.go
@@ -39,7 +39,7 @@ type Mockbeat struct {
 }
 
 // Creates beater
-func New(b *beat.Beat, _ *common.Config) (beat.Beater, error) {
+func New(_ *beat.Beat, _ *common.Config) (beat.Beater, error) {
 	return &Mockbeat{
 		done:   make(chan struct{}),
 		logger: logp.NewLogger("mock"),

--- a/libbeat/mock/mockbeat.go
+++ b/libbeat/mock/mockbeat.go
@@ -39,7 +39,7 @@ type Mockbeat struct {
 }
 
 // Creates beater
-func New(_ *beat.Beat, _ *common.Config) (beat.Beater, error) {
+func New(b *beat.Beat, _ *common.Config) (beat.Beater, error) {
 	return &Mockbeat{
 		done:   make(chan struct{}),
 		logger: logp.NewLogger("mock"),


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

Uses the correct beat name on state registy

## Why is it important?

Fixes #27755

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] I have added tests

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

On any beat, enable the "HTTP endpoint" by adding this at the end of your beat yaml:
```yml
http:
  enabled: true
  host: 0.0.0.0
  port: 5066
```

Start your beat and make a request to `5066/state`:
```sh
curl 127.0.0.1:5066/state | jq
```

## Related issues

- Closes #27755

