### PR TITLE
Fix CRI max_bytes truncation for oversized first chunks

### DIFF
--- a/changelog/fragments/1778172750-fix-cri-max-bytes-first-chunk.yaml
+++ b/changelog/fragments/1778172750-fix-cri-max-bytes-first-chunk.yaml
@@ -1,0 +1,3 @@
+kind: bug-fix
+summary: Truncate oversized first CRI partial chunks to max_bytes during reassembly
+component: filebeat

--- a/libbeat/reader/readjson/docker_json.go
+++ b/libbeat/reader/readjson/docker_json.go
@@ -266,9 +266,17 @@ func (p *DockerJSONReader) Next() (reader.Message, error) {
 			if p.maxBytes > 0 && len(message.Content)+len(next.Content) > p.maxBytes {
 				remaining := p.maxBytes - len(message.Content)
 				if remaining < 0 {
-					message.Content = message.Content[:p.maxBytes]
+					// Just cutting the slice won't shrink the underlying array,
+					// so we create a slice the size we want and copy the data.
+					msg := make([]byte, p.maxBytes)
+					copy(msg, message.Content[:p.maxBytes])
+					message.Content = msg
 				} else if remaining > 0 {
 					message.Content = append(message.Content, next.Content[:remaining]...)
+					// Make sure the underlaying array is the same size as the content
+					msg := make([]byte, p.maxBytes)
+					copy(msg, message.Content)
+					message.Content = msg
 				}
 				_ = message.AddFlagsWithKey("log.flags", "truncated")
 				truncated = true

--- a/libbeat/reader/readjson/docker_json.go
+++ b/libbeat/reader/readjson/docker_json.go
@@ -43,8 +43,7 @@ type DockerJSONReader struct {
 	// parse CRI flags
 	criflags bool
 
-	// maximum number of bytes to use when reassembling partial CRI/docker log lines;
-	// limits growth while joining fragments but does not cap the size of the initial chunk.
+	// maximum number of bytes to use when reassembling partial CRI/docker log lines.
 	// A value of 0 means no limit is applied during reassembly.
 	maxBytes int
 
@@ -266,7 +265,9 @@ func (p *DockerJSONReader) Next() (reader.Message, error) {
 			}
 			if p.maxBytes > 0 && len(message.Content)+len(next.Content) > p.maxBytes {
 				remaining := p.maxBytes - len(message.Content)
-				if remaining > 0 {
+				if remaining < 0 {
+					message.Content = message.Content[:p.maxBytes]
+				} else if remaining > 0 {
 					message.Content = append(message.Content, next.Content[:remaining]...)
 				}
 				_ = message.AddFlagsWithKey("log.flags", "truncated")

--- a/libbeat/reader/readjson/docker_json_test.go
+++ b/libbeat/reader/readjson/docker_json_test.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/elastic/beats/v7/libbeat/reader"
 	"github.com/elastic/elastic-agent-libs/logp"
@@ -405,6 +406,28 @@ func TestDockerJSONMaxBytes(t *testing.T) {
 	// consumed by this single Next() call. If any remain, subsequent calls
 	// would emit orphaned partial chunks as separate events, breaking alignment.
 	assert.Empty(t, r.messages, "all partial chunks must be drained before returning")
+}
+
+func TestDockerJSONMaxBytesFirstChunkAlreadyTooLarge(t *testing.T) {
+	maxBytes := 5
+	inputs := [][]byte{
+		[]byte("2017-10-12T13:32:21.232861448Z stdout P abcdefghij"),
+		[]byte("2017-10-12T13:32:21.232861448Z stdout F klmnopqrst"),
+	}
+
+	r := &mockReader{messages: inputs}
+	json := New(r, "stdout", true, "cri", true, maxBytes, logp.NewNopLogger())
+	message, err := json.Next()
+
+	require.NoError(t, err)
+	// convert message.Content to string to make it more human-readable
+	require.Len(t, string(message.Content), maxBytes, "content should be capped at maxBytes")
+
+	flags, err := message.Fields.GetValue("log.flags")
+	require.NoError(t, err, "'log.flags' not present in event")
+	require.Contains(t, flags, "truncated", "truncated flag should be set")
+
+	require.Empty(t, r.messages, "all partial chunks must be drained before returning")
 }
 
 type mockReader struct {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Proposed commit message

Fix CRI max_bytes truncation for oversized first chunks.

When a CRI partial line starts with a first chunk larger than `max_bytes`, the reassembly path computes a negative `remaining` value and previously only set `log.flags: [truncated]` without actually trimming `message.Content`. This change truncates the existing content to `max_bytes` when `remaining < 0`, preserving the `max_bytes` contract and keeping partial-drain behavior unchanged.

A regression test was added in `libbeat/reader/readjson/docker_json_test.go` for the exact scenario reported in #49943.

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).

## Disruptive User Impact

None expected. This fixes behavior to match configured `max_bytes` limits for CRI partial reassembly.

## How to test this PR locally

```bash
go test ./libbeat/reader/readjson -run 'TestDockerJSONMaxBytes|TestDockerJSONMaxBytesFirstChunkAlreadyTooLarge' -count=1
```

## Related issues

- Closes #49943

## Use cases

- CRI logs where the first `P` chunk alone exceeds `max_bytes` now emit content capped at `max_bytes` and include the `truncated` flag.

## Screenshots

N/A

## Logs

```text
ok  github.com/elastic/beats/v7/libbeat/reader/readjson  0.004s
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6db92ebb-a100-411a-acc3-75a79edf39ac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6db92ebb-a100-411a-acc3-75a79edf39ac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

