### PR TITLE
Configure Docker metadata wait behavior

### DIFF
--- a/auditbeat/auditbeat.reference.yml
+++ b/auditbeat/auditbeat.reference.yml
@@ -343,7 +343,8 @@ auditbeat.modules:
 #      match_short_id: false
 #      cleanup_timeout: 60
 #      labels.dedot: false
-#      connection_retry_interval: 10s
+#      wait_for_metadata: false
+#      wait_for_metadata_timeout: 30s
 #      # To connect to Docker over TLS you must specify a client and CA certificate.
 #      #ssl:
 #      #  certificate_authority: "/etc/pki/root/ca.pem"

--- a/auditbeat/auditbeat.reference.yml
+++ b/auditbeat/auditbeat.reference.yml
@@ -345,6 +345,7 @@ auditbeat.modules:
 #      labels.dedot: false
 #      wait_for_metadata: false
 #      wait_for_metadata_timeout: 30s
+#      wait_for_metadata_retry_period: 10s
 #      # To connect to Docker over TLS you must specify a client and CA certificate.
 #      #ssl:
 #      #  certificate_authority: "/etc/pki/root/ca.pem"

--- a/changelog/fragments/1778617667-retry-add_docker_metadata.yaml
+++ b/changelog/fragments/1778617667-retry-add_docker_metadata.yaml
@@ -22,7 +22,8 @@ description: |
   The `add_docker_metadata` processor now retries connecting to Docker
   until `wait_for_metadata_timeout` expires. Set `wait_for_metadata`
   to true to block startup until Docker metadata is available. A
-  `wait_for_metadata_timeout` value of zero retries indefinitely.
+  `wait_for_metadata_timeout` value of zero retries indefinitely. Configure
+  retry cadence with `wait_for_metadata_retry_period`.
 
 # REQUIRED for breaking-change, deprecation, known-issue
 # impact:

--- a/changelog/fragments/1778617667-retry-add_docker_metadata.yaml
+++ b/changelog/fragments/1778617667-retry-add_docker_metadata.yaml
@@ -20,9 +20,9 @@ summary: Retry connecting to Docker in `add_docker_metadata` when the initial co
 # this field accommodate a description without length limits.
 description: |
   The `add_docker_metadata` processor now retries connecting to Docker
-  every 10s until it succeeds. The interval can be configured by
-  setting `connection_retry_interval`. A value of zero disables
-  connection retries.
+  until `wait_for_metadata_timeout` expires. Set `wait_for_metadata`
+  to true to block startup until Docker metadata is available. A
+  `wait_for_metadata_timeout` value of zero retries indefinitely.
 
 # REQUIRED for breaking-change, deprecation, known-issue
 # impact:

--- a/docs/reference/auditbeat/add-docker-metadata.md
+++ b/docs/reference/auditbeat/add-docker-metadata.md
@@ -47,6 +47,7 @@ processors:
       #labels.dedot: false
       #wait_for_metadata: false
       #wait_for_metadata_timeout: 30s
+      #wait_for_metadata_retry_period: 10s
       # To connect to Docker over TLS you must specify a client and CA certificate.
       #ssl:
       #  certificate_authority: "/etc/pki/root/ca.pem"
@@ -91,4 +92,7 @@ It has the following settings:
 
 `wait_for_metadata_timeout`
 :   (Optional) The maximum time allowed for the processor to connect to Docker and fetch metadata. Applies regardless of `wait_for_metadata`. To retry the connection indefinitely, set to `0`. Defaults to `30s`.
+
+`wait_for_metadata_retry_period`
+:   (Optional) How long to wait between Docker connection retry attempts. Defaults to `10s`.
 

--- a/docs/reference/auditbeat/add-docker-metadata.md
+++ b/docs/reference/auditbeat/add-docker-metadata.md
@@ -10,7 +10,7 @@ applies_to:
 # Add Docker metadata [add-docker-metadata]
 
 
-The `add_docker_metadata` processor annotates each event with relevant metadata from Docker containers. At startup it detects a docker environment and caches the metadata. The events are annotated with Docker metadata, only if a valid configuration is detected and the processor is able to reach Docker API. If Docker is unavailable at startup, the processor retries the connection at the configured `connection_retry_interval` until it succeeds.
+The `add_docker_metadata` processor annotates each event with relevant metadata from Docker containers. At startup it detects a docker environment and caches the metadata. The events are annotated with Docker metadata, only if a valid configuration is detected and the processor is able to reach Docker API. If Docker is unavailable at startup, the processor retries the connection until `wait_for_metadata_timeout` expires. Set `wait_for_metadata` to `true` to block startup until Docker metadata is available.
 
 Each event is annotated with:
 
@@ -45,7 +45,8 @@ processors:
       #match_short_id: true
       #cleanup_timeout: 60
       #labels.dedot: false
-      #connection_retry_interval: 10s
+      #wait_for_metadata: false
+      #wait_for_metadata_timeout: 30s
       # To connect to Docker over TLS you must specify a client and CA certificate.
       #ssl:
       #  certificate_authority: "/etc/pki/root/ca.pem"
@@ -85,6 +86,9 @@ It has the following settings:
 `labels.dedot`
 :   (Optional) Default to be false. If set to true, replace dots in labels with `_`.
 
-`connection_retry_interval`
-:   (Optional) Retry interval used when Docker is not reachable during processor initialization. Defaults to `10s`. Set to `0` to deactivate retries after an initial connection failure.
+`wait_for_metadata`
+:   (Optional) When `true`, startup is blocked until the processor connects to Docker and metadata is available. If the processor can't connect to Docker within the duration set in `wait_for_metadata_timeout`, startup fails and the process exits. When `false`, the processor retries the connection asynchronously. Defaults to `false`.
+
+`wait_for_metadata_timeout`
+:   (Optional) The maximum time allowed for the processor to connect to Docker and fetch metadata. Applies regardless of `wait_for_metadata`. To retry the connection indefinitely, set to `0`. Defaults to `30s`.
 

--- a/docs/reference/filebeat/add-docker-metadata.md
+++ b/docs/reference/filebeat/add-docker-metadata.md
@@ -47,6 +47,7 @@ processors:
       #labels.dedot: false
       #wait_for_metadata: false
       #wait_for_metadata_timeout: 30s
+      #wait_for_metadata_retry_period: 10s
       # To connect to Docker over TLS you must specify a client and CA certificate.
       #ssl:
       #  certificate_authority: "/etc/pki/root/ca.pem"
@@ -91,4 +92,7 @@ It has the following settings:
 
 `wait_for_metadata_timeout`
 :   (Optional) The maximum time allowed for the processor to connect to Docker and fetch metadata. Applies regardless of `wait_for_metadata`. To retry the connection indefinitely, set to `0`. Defaults to `30s`.
+
+`wait_for_metadata_retry_period`
+:   (Optional) How long to wait between Docker connection retry attempts. Defaults to `10s`.
 

--- a/docs/reference/filebeat/add-docker-metadata.md
+++ b/docs/reference/filebeat/add-docker-metadata.md
@@ -10,7 +10,7 @@ applies_to:
 # Add Docker metadata [add-docker-metadata]
 
 
-The `add_docker_metadata` processor annotates each event with relevant metadata from Docker containers. At startup it detects a docker environment and caches the metadata. The events are annotated with Docker metadata, only if a valid configuration is detected and the processor is able to reach Docker API. If Docker is unavailable at startup, the processor retries the connection at the configured `connection_retry_interval` until it succeeds.
+The `add_docker_metadata` processor annotates each event with relevant metadata from Docker containers. At startup it detects a docker environment and caches the metadata. The events are annotated with Docker metadata, only if a valid configuration is detected and the processor is able to reach Docker API. If Docker is unavailable at startup, the processor retries the connection until `wait_for_metadata_timeout` expires. Set `wait_for_metadata` to `true` to block startup until Docker metadata is available.
 
 Each event is annotated with:
 
@@ -45,7 +45,8 @@ processors:
       #match_short_id: true
       #cleanup_timeout: 60
       #labels.dedot: false
-      #connection_retry_interval: 10s
+      #wait_for_metadata: false
+      #wait_for_metadata_timeout: 30s
       # To connect to Docker over TLS you must specify a client and CA certificate.
       #ssl:
       #  certificate_authority: "/etc/pki/root/ca.pem"
@@ -85,6 +86,9 @@ It has the following settings:
 `labels.dedot`
 :   (Optional) Defaults to true. When true, replaces dots (`.`) in labels with underscores (`_`).
 
-`connection_retry_interval`
-:   (Optional) Retry interval used when Docker is not reachable during processor initialization. Defaults to `10s`. Set to `0` to deactivate retries after an initial connection failure.
+`wait_for_metadata`
+:   (Optional) When `true`, startup is blocked until the processor connects to Docker and metadata is available. If the processor can't connect to Docker within the duration set in `wait_for_metadata_timeout`, startup fails and the process exits. When `false`, the processor retries the connection asynchronously. Defaults to `false`.
+
+`wait_for_metadata_timeout`
+:   (Optional) The maximum time allowed for the processor to connect to Docker and fetch metadata. Applies regardless of `wait_for_metadata`. To retry the connection indefinitely, set to `0`. Defaults to `30s`.
 

--- a/docs/reference/heartbeat/add-docker-metadata.md
+++ b/docs/reference/heartbeat/add-docker-metadata.md
@@ -47,6 +47,7 @@ processors:
       #labels.dedot: false
       #wait_for_metadata: false
       #wait_for_metadata_timeout: 30s
+      #wait_for_metadata_retry_period: 10s
       # To connect to Docker over TLS you must specify a client and CA certificate.
       #ssl:
       #  certificate_authority: "/etc/pki/root/ca.pem"
@@ -91,4 +92,7 @@ It has the following settings:
 
 `wait_for_metadata_timeout`
 :   (Optional) The maximum time allowed for the processor to connect to Docker and fetch metadata. Applies regardless of `wait_for_metadata`. To retry the connection indefinitely, set to `0`. Defaults to `30s`.
+
+`wait_for_metadata_retry_period`
+:   (Optional) How long to wait between Docker connection retry attempts. Defaults to `10s`.
 

--- a/docs/reference/heartbeat/add-docker-metadata.md
+++ b/docs/reference/heartbeat/add-docker-metadata.md
@@ -10,7 +10,7 @@ applies_to:
 # Add Docker metadata [add-docker-metadata]
 
 
-The `add_docker_metadata` processor annotates each event with relevant metadata from Docker containers. At startup it detects a docker environment and caches the metadata. The events are annotated with Docker metadata, only if a valid configuration is detected and the processor is able to reach Docker API. If Docker is unavailable at startup, the processor retries the connection at the configured `connection_retry_interval` until it succeeds.
+The `add_docker_metadata` processor annotates each event with relevant metadata from Docker containers. At startup it detects a docker environment and caches the metadata. The events are annotated with Docker metadata, only if a valid configuration is detected and the processor is able to reach Docker API. If Docker is unavailable at startup, the processor retries the connection until `wait_for_metadata_timeout` expires. Set `wait_for_metadata` to `true` to block startup until Docker metadata is available.
 
 Each event is annotated with:
 
@@ -45,7 +45,8 @@ processors:
       #match_short_id: true
       #cleanup_timeout: 60
       #labels.dedot: false
-      #connection_retry_interval: 10s
+      #wait_for_metadata: false
+      #wait_for_metadata_timeout: 30s
       # To connect to Docker over TLS you must specify a client and CA certificate.
       #ssl:
       #  certificate_authority: "/etc/pki/root/ca.pem"
@@ -85,6 +86,9 @@ It has the following settings:
 `labels.dedot`
 :   (Optional) Default to be false. If set to true, replace dots in labels with `_`.
 
-`connection_retry_interval`
-:   (Optional) Retry interval used when Docker is not reachable during processor initialization. Defaults to `10s`. Set to `0` to deactivate retries after an initial connection failure.
+`wait_for_metadata`
+:   (Optional) When `true`, startup is blocked until the processor connects to Docker and metadata is available. If the processor can't connect to Docker within the duration set in `wait_for_metadata_timeout`, startup fails and the process exits. When `false`, the processor retries the connection asynchronously. Defaults to `false`.
+
+`wait_for_metadata_timeout`
+:   (Optional) The maximum time allowed for the processor to connect to Docker and fetch metadata. Applies regardless of `wait_for_metadata`. To retry the connection indefinitely, set to `0`. Defaults to `30s`.
 

--- a/docs/reference/metricbeat/add-docker-metadata.md
+++ b/docs/reference/metricbeat/add-docker-metadata.md
@@ -47,6 +47,7 @@ processors:
       #labels.dedot: false
       #wait_for_metadata: false
       #wait_for_metadata_timeout: 30s
+      #wait_for_metadata_retry_period: 10s
       # To connect to Docker over TLS you must specify a client and CA certificate.
       #ssl:
       #  certificate_authority: "/etc/pki/root/ca.pem"
@@ -91,4 +92,7 @@ It has the following settings:
 
 `wait_for_metadata_timeout`
 :   (Optional) The maximum time allowed for the processor to connect to Docker and fetch metadata. Applies regardless of `wait_for_metadata`. To retry the connection indefinitely, set to `0`. Defaults to `30s`.
+
+`wait_for_metadata_retry_period`
+:   (Optional) How long to wait between Docker connection retry attempts. Defaults to `10s`.
 

--- a/docs/reference/metricbeat/add-docker-metadata.md
+++ b/docs/reference/metricbeat/add-docker-metadata.md
@@ -10,7 +10,7 @@ applies_to:
 # Add Docker metadata [add-docker-metadata]
 
 
-The `add_docker_metadata` processor annotates each event with relevant metadata from Docker containers. At startup it detects a docker environment and caches the metadata. The events are annotated with Docker metadata, only if a valid configuration is detected and the processor is able to reach Docker API. If Docker is unavailable at startup, the processor retries the connection at the configured `connection_retry_interval` until it succeeds.
+The `add_docker_metadata` processor annotates each event with relevant metadata from Docker containers. At startup it detects a docker environment and caches the metadata. The events are annotated with Docker metadata, only if a valid configuration is detected and the processor is able to reach Docker API. If Docker is unavailable at startup, the processor retries the connection until `wait_for_metadata_timeout` expires. Set `wait_for_metadata` to `true` to block startup until Docker metadata is available.
 
 Each event is annotated with:
 
@@ -45,7 +45,8 @@ processors:
       #match_short_id: true
       #cleanup_timeout: 60
       #labels.dedot: false
-      #connection_retry_interval: 10s
+      #wait_for_metadata: false
+      #wait_for_metadata_timeout: 30s
       # To connect to Docker over TLS you must specify a client and CA certificate.
       #ssl:
       #  certificate_authority: "/etc/pki/root/ca.pem"
@@ -85,6 +86,9 @@ It has the following settings:
 `labels.dedot`
 :   (Optional) Default to be false. If set to true, replace dots in labels with `_`.
 
-`connection_retry_interval`
-:   (Optional) Retry interval used when Docker is not reachable during processor initialization. Defaults to `10s`. Set to `0` to deactivate retries after an initial connection failure.
+`wait_for_metadata`
+:   (Optional) When `true`, startup is blocked until the processor connects to Docker and metadata is available. If the processor can't connect to Docker within the duration set in `wait_for_metadata_timeout`, startup fails and the process exits. When `false`, the processor retries the connection asynchronously. Defaults to `false`.
+
+`wait_for_metadata_timeout`
+:   (Optional) The maximum time allowed for the processor to connect to Docker and fetch metadata. Applies regardless of `wait_for_metadata`. To retry the connection indefinitely, set to `0`. Defaults to `30s`.
 

--- a/docs/reference/winlogbeat/add-docker-metadata.md
+++ b/docs/reference/winlogbeat/add-docker-metadata.md
@@ -47,6 +47,7 @@ processors:
       #labels.dedot: false
       #wait_for_metadata: false
       #wait_for_metadata_timeout: 30s
+      #wait_for_metadata_retry_period: 10s
       # To connect to Docker over TLS you must specify a client and CA certificate.
       #ssl:
       #  certificate_authority: "/etc/pki/root/ca.pem"
@@ -91,4 +92,7 @@ It has the following settings:
 
 `wait_for_metadata_timeout`
 :   (Optional) The maximum time allowed for the processor to connect to Docker and fetch metadata. Applies regardless of `wait_for_metadata`. To retry the connection indefinitely, set to `0`. Defaults to `30s`.
+
+`wait_for_metadata_retry_period`
+:   (Optional) How long to wait between Docker connection retry attempts. Defaults to `10s`.
 

--- a/docs/reference/winlogbeat/add-docker-metadata.md
+++ b/docs/reference/winlogbeat/add-docker-metadata.md
@@ -10,7 +10,7 @@ applies_to:
 # Add Docker metadata [add-docker-metadata]
 
 
-The `add_docker_metadata` processor annotates each event with relevant metadata from Docker containers. At startup it detects a docker environment and caches the metadata. The events are annotated with Docker metadata, only if a valid configuration is detected and the processor is able to reach Docker API. If Docker is unavailable at startup, the processor retries the connection at the configured `connection_retry_interval` until it succeeds.
+The `add_docker_metadata` processor annotates each event with relevant metadata from Docker containers. At startup it detects a docker environment and caches the metadata. The events are annotated with Docker metadata, only if a valid configuration is detected and the processor is able to reach Docker API. If Docker is unavailable at startup, the processor retries the connection until `wait_for_metadata_timeout` expires. Set `wait_for_metadata` to `true` to block startup until Docker metadata is available.
 
 Each event is annotated with:
 
@@ -45,7 +45,8 @@ processors:
       #match_short_id: true
       #cleanup_timeout: 60
       #labels.dedot: false
-      #connection_retry_interval: 10s
+      #wait_for_metadata: false
+      #wait_for_metadata_timeout: 30s
       # To connect to Docker over TLS you must specify a client and CA certificate.
       #ssl:
       #  certificate_authority: "/etc/pki/root/ca.pem"
@@ -85,6 +86,9 @@ It has the following settings:
 `labels.dedot`
 :   (Optional) Default to be false. If set to true, replace dots in labels with `_`.
 
-`connection_retry_interval`
-:   (Optional) Retry interval used when Docker is not reachable during processor initialization. Defaults to `10s`. Set to `0` to deactivate retries after an initial connection failure.
+`wait_for_metadata`
+:   (Optional) When `true`, startup is blocked until the processor connects to Docker and metadata is available. If the processor can't connect to Docker within the duration set in `wait_for_metadata_timeout`, startup fails and the process exits. When `false`, the processor retries the connection asynchronously. Defaults to `false`.
+
+`wait_for_metadata_timeout`
+:   (Optional) The maximum time allowed for the processor to connect to Docker and fetch metadata. Applies regardless of `wait_for_metadata`. To retry the connection indefinitely, set to `0`. Defaults to `30s`.
 

--- a/filebeat/filebeat.reference.yml
+++ b/filebeat/filebeat.reference.yml
@@ -1613,7 +1613,8 @@ filebeat.inputs:
 #      match_short_id: false
 #      cleanup_timeout: 60
 #      labels.dedot: false
-#      connection_retry_interval: 10s
+#      wait_for_metadata: false
+#      wait_for_metadata_timeout: 30s
 #      # To connect to Docker over TLS you must specify a client and CA certificate.
 #      #ssl:
 #      #  certificate_authority: "/etc/pki/root/ca.pem"

--- a/filebeat/filebeat.reference.yml
+++ b/filebeat/filebeat.reference.yml
@@ -1615,6 +1615,7 @@ filebeat.inputs:
 #      labels.dedot: false
 #      wait_for_metadata: false
 #      wait_for_metadata_timeout: 30s
+#      wait_for_metadata_retry_period: 10s
 #      # To connect to Docker over TLS you must specify a client and CA certificate.
 #      #ssl:
 #      #  certificate_authority: "/etc/pki/root/ca.pem"

--- a/heartbeat/heartbeat.reference.yml
+++ b/heartbeat/heartbeat.reference.yml
@@ -428,6 +428,7 @@ heartbeat.jobs:
 #      labels.dedot: false
 #      wait_for_metadata: false
 #      wait_for_metadata_timeout: 30s
+#      wait_for_metadata_retry_period: 10s
 #      # To connect to Docker over TLS you must specify a client and CA certificate.
 #      #ssl:
 #      #  certificate_authority: "/etc/pki/root/ca.pem"

--- a/heartbeat/heartbeat.reference.yml
+++ b/heartbeat/heartbeat.reference.yml
@@ -426,7 +426,8 @@ heartbeat.jobs:
 #      match_short_id: false
 #      cleanup_timeout: 60
 #      labels.dedot: false
-#      connection_retry_interval: 10s
+#      wait_for_metadata: false
+#      wait_for_metadata_timeout: 30s
 #      # To connect to Docker over TLS you must specify a client and CA certificate.
 #      #ssl:
 #      #  certificate_authority: "/etc/pki/root/ca.pem"

--- a/libbeat/_meta/config/processors.reference.yml.tmpl
+++ b/libbeat/_meta/config/processors.reference.yml.tmpl
@@ -73,6 +73,7 @@
 #      labels.dedot: false
 #      wait_for_metadata: false
 #      wait_for_metadata_timeout: 30s
+#      wait_for_metadata_retry_period: 10s
 #      # To connect to Docker over TLS you must specify a client and CA certificate.
 #      #ssl:
 #      #  certificate_authority: "/etc/pki/root/ca.pem"

--- a/libbeat/_meta/config/processors.reference.yml.tmpl
+++ b/libbeat/_meta/config/processors.reference.yml.tmpl
@@ -71,7 +71,8 @@
 #      match_short_id: false
 #      cleanup_timeout: 60
 #      labels.dedot: false
-#      connection_retry_interval: 10s
+#      wait_for_metadata: false
+#      wait_for_metadata_timeout: 30s
 #      # To connect to Docker over TLS you must specify a client and CA certificate.
 #      #ssl:
 #      #  certificate_authority: "/etc/pki/root/ca.pem"

--- a/libbeat/processors/add_docker_metadata/add_docker_metadata.go
+++ b/libbeat/processors/add_docker_metadata/add_docker_metadata.go
@@ -49,8 +49,6 @@ const (
 	cgroupCacheExpiration = 5 * time.Minute
 )
 
-var dockerMetadataRetryInterval = 10 * time.Second
-
 // initCgroupPaths initializes a new cgroup reader. This enables
 // unit testing by allowing us to stub the OS interface.
 var initCgroupPaths processors.InitCgroupHandler = func(rootfsMountpoint resolve.Resolver, ignoreRootCgroups bool) (processors.CGReader, error) {
@@ -77,6 +75,8 @@ type addDockerMetadata struct {
 	closeRetry      chan struct{} // Channel to signal the connection retry goroutine to stop
 	waitRetry       sync.WaitGroup
 	cgreader        processors.CGReader
+	retryPeriod     time.Duration // Period to wait when reconnecting to Docker
+	retryTimeout    time.Duration // Maximum time to wait when connecting to Docker, 0 means wait forever.
 }
 
 const selector = "add_docker_metadata"
@@ -123,6 +123,8 @@ func buildDockerMetadataProcessor(log *logp.Logger, cfg *conf.C, watcherConstruc
 		dedot:           config.DeDot,
 		cgreader:        reader,
 		closeRetry:      make(chan struct{}),
+		retryPeriod:     config.WaitMetadataRetry,
+		retryTimeout:    config.WaitMetadataTimeout,
 	}
 
 	constructAndStartWatcher := func() docker.Watcher {
@@ -156,7 +158,7 @@ func buildDockerMetadataProcessor(log *logp.Logger, cfg *conf.C, watcherConstruc
 
 	if !connectToDocker() {
 		if config.WaitMetadata {
-			connected, _ := dm.retryConnectToDocker(connectToDocker, config.WaitMetadataTimeout)
+			connected, _ := dm.retryConnectToDocker(connectToDocker)
 			if !connected {
 				if err := processors.Close(dm.sourceProcessor); err != nil {
 					dm.log.Debugf("error closing source processor after docker connection timeout: %v", err)
@@ -165,44 +167,39 @@ func buildDockerMetadataProcessor(log *logp.Logger, cfg *conf.C, watcherConstruc
 			}
 		} else {
 			// If docker is not available, try reconnecting asynchronously until the timeout expires.
-			dm.startDockerConnectionRetry(connectToDocker, config.WaitMetadataTimeout)
+			dm.startDockerConnectionRetry(connectToDocker)
 		}
 	}
 
 	return &dm, nil
 }
 
-func (d *addDockerMetadata) startDockerConnectionRetry(connectToDocker func() bool, timeout time.Duration) {
+func (d *addDockerMetadata) startDockerConnectionRetry(connectToDocker func() bool) {
 	d.waitRetry.Go(func() {
 		defer d.log.Debug("retry goroutine done")
-		connected, stopped := d.retryConnectToDocker(connectToDocker, timeout)
+		connected, stopped := d.retryConnectToDocker(connectToDocker)
 		if !connected && !stopped {
 			d.log.Warnf(
 				"stopped retrying docker connection before metadata became available; wait_for_metadata_timeout=%s elapsed",
-				timeout,
+				d.retryTimeout,
 			)
 		}
 	})
 }
 
-func (d *addDockerMetadata) retryConnectToDocker(connectToDocker func() bool, timeout time.Duration) (connected bool, stopped bool) {
+func (d *addDockerMetadata) retryConnectToDocker(connectToDocker func() bool) (connected bool, stopped bool) {
 	d.log.Warnf(
 		"could not connect to docker, retrying asynchronously using "+
 			"wait_for_metadata_timeout=%s (0 means indefinitely)",
-		timeout,
+		d.retryTimeout,
 	)
 
-	retryInterval := dockerMetadataRetryInterval
-	if retryInterval <= 0 {
-		retryInterval = 10 * time.Second
-	}
-
-	ticker := time.NewTicker(retryInterval)
+	ticker := time.NewTicker(d.retryPeriod)
 	defer ticker.Stop()
 
 	var timeoutC <-chan time.Time
-	if timeout > 0 {
-		timeoutC = time.Tick(timeout)
+	if d.retryTimeout > 0 {
+		timeoutC = time.Tick(d.retryTimeout)
 	}
 
 	for {

--- a/libbeat/processors/add_docker_metadata/add_docker_metadata.go
+++ b/libbeat/processors/add_docker_metadata/add_docker_metadata.go
@@ -156,10 +156,6 @@ func buildDockerMetadataProcessor(log *logp.Logger, cfg *conf.C, watcherConstruc
 
 	if !connectToDocker() {
 		if config.WaitMetadata {
-			dm.log.Warnf(
-				"could not connect to docker, retrying using wait_for_metadata_timeout=%s",
-				waitForMetadataTimeoutLabel(config.WaitMetadataTimeout),
-			)
 			connected, _ := dm.retryConnectToDocker(connectToDocker, config.WaitMetadataTimeout)
 			if !connected {
 				if err := processors.Close(dm.sourceProcessor); err != nil {
@@ -169,22 +165,11 @@ func buildDockerMetadataProcessor(log *logp.Logger, cfg *conf.C, watcherConstruc
 			}
 		} else {
 			// If docker is not available, try reconnecting asynchronously until the timeout expires.
-			dm.log.Warnf(
-				"could not connect to docker, retrying asynchronously using wait_for_metadata_timeout=%s",
-				waitForMetadataTimeoutLabel(config.WaitMetadataTimeout),
-			)
 			dm.startDockerConnectionRetry(connectToDocker, config.WaitMetadataTimeout)
 		}
 	}
 
 	return &dm, nil
-}
-
-func waitForMetadataTimeoutLabel(timeout time.Duration) string {
-	if timeout == 0 {
-		return "0 (retrying indefinitely)"
-	}
-	return timeout.String()
 }
 
 func (d *addDockerMetadata) startDockerConnectionRetry(connectToDocker func() bool, timeout time.Duration) {
@@ -194,13 +179,19 @@ func (d *addDockerMetadata) startDockerConnectionRetry(connectToDocker func() bo
 		if !connected && !stopped {
 			d.log.Warnf(
 				"stopped retrying docker connection before metadata became available; wait_for_metadata_timeout=%s elapsed",
-				waitForMetadataTimeoutLabel(timeout),
+				timeout,
 			)
 		}
 	})
 }
 
 func (d *addDockerMetadata) retryConnectToDocker(connectToDocker func() bool, timeout time.Duration) (connected bool, stopped bool) {
+	d.log.Warnf(
+		"could not connect to docker, retrying asynchronously using "+
+			"wait_for_metadata_timeout=%s (0 means indefinitely)",
+		timeout,
+	)
+
 	retryInterval := dockerMetadataRetryInterval
 	if retryInterval <= 0 {
 		retryInterval = 10 * time.Second
@@ -210,11 +201,8 @@ func (d *addDockerMetadata) retryConnectToDocker(connectToDocker func() bool, ti
 	defer ticker.Stop()
 
 	var timeoutC <-chan time.Time
-	var timeoutTimer *time.Timer
 	if timeout > 0 {
-		timeoutTimer = time.NewTimer(timeout)
-		timeoutC = timeoutTimer.C
-		defer timeoutTimer.Stop()
+		timeoutC = time.Tick(timeout)
 	}
 
 	for {

--- a/libbeat/processors/add_docker_metadata/add_docker_metadata.go
+++ b/libbeat/processors/add_docker_metadata/add_docker_metadata.go
@@ -49,6 +49,8 @@ const (
 	cgroupCacheExpiration = 5 * time.Minute
 )
 
+var dockerMetadataRetryInterval = 10 * time.Second
+
 // initCgroupPaths initializes a new cgroup reader. This enables
 // unit testing by allowing us to stub the OS interface.
 var initCgroupPaths processors.InitCgroupHandler = func(rootfsMountpoint resolve.Resolver, ignoreRootCgroups bool) (processors.CGReader, error) {
@@ -141,36 +143,92 @@ func buildDockerMetadataProcessor(log *logp.Logger, cfg *conf.C, watcherConstruc
 		return watcher
 	}
 
-	if watcher := constructAndStartWatcher(); watcher != nil {
+	connectToDocker := func() bool {
+		watcher := constructAndStartWatcher()
+		if watcher == nil {
+			return false
+		}
+
 		dm.watcher = watcher
 		dm.dockerAvailable.Store(true)
-	} else if config.ConnectionRetryInterval > 0 {
-		// If docker is not available, try reconnecting at set intervals
-		dm.log.Warn(
-			"could not connect to docker, trying to reconnect every %s.",
-			config.ConnectionRetryInterval,
-		)
-		dm.waitRetry.Go(func() {
-			defer dm.log.Debug("retry goroutine done")
+		return true
+	}
 
-			ticker := time.Tick(config.ConnectionRetryInterval)
-
-			for {
-				select {
-				case <-ticker:
-					if watcher := constructAndStartWatcher(); watcher != nil {
-						dm.watcher = watcher
-						dm.dockerAvailable.Store(true)
-						return
-					}
-				case <-dm.closeRetry:
-					return
+	if !connectToDocker() {
+		if config.WaitMetadata {
+			dm.log.Warnf(
+				"could not connect to docker, retrying using wait_for_metadata_timeout=%s",
+				waitForMetadataTimeoutLabel(config.WaitMetadataTimeout),
+			)
+			connected, _ := dm.retryConnectToDocker(connectToDocker, config.WaitMetadataTimeout)
+			if !connected {
+				if err := processors.Close(dm.sourceProcessor); err != nil {
+					dm.log.Debugf("error closing source processor after docker connection timeout: %v", err)
 				}
+				return nil, fmt.Errorf("%s: could not connect to docker", processorName)
 			}
-		})
+		} else {
+			// If docker is not available, try reconnecting asynchronously until the timeout expires.
+			dm.log.Warnf(
+				"could not connect to docker, retrying asynchronously using wait_for_metadata_timeout=%s",
+				waitForMetadataTimeoutLabel(config.WaitMetadataTimeout),
+			)
+			dm.startDockerConnectionRetry(connectToDocker, config.WaitMetadataTimeout)
+		}
 	}
 
 	return &dm, nil
+}
+
+func waitForMetadataTimeoutLabel(timeout time.Duration) string {
+	if timeout == 0 {
+		return "0 (retrying indefinitely)"
+	}
+	return timeout.String()
+}
+
+func (d *addDockerMetadata) startDockerConnectionRetry(connectToDocker func() bool, timeout time.Duration) {
+	d.waitRetry.Go(func() {
+		defer d.log.Debug("retry goroutine done")
+		connected, stopped := d.retryConnectToDocker(connectToDocker, timeout)
+		if !connected && !stopped {
+			d.log.Warnf(
+				"stopped retrying docker connection before metadata became available; wait_for_metadata_timeout=%s elapsed",
+				waitForMetadataTimeoutLabel(timeout),
+			)
+		}
+	})
+}
+
+func (d *addDockerMetadata) retryConnectToDocker(connectToDocker func() bool, timeout time.Duration) (connected bool, stopped bool) {
+	retryInterval := dockerMetadataRetryInterval
+	if retryInterval <= 0 {
+		retryInterval = 10 * time.Second
+	}
+
+	ticker := time.NewTicker(retryInterval)
+	defer ticker.Stop()
+
+	var timeoutC <-chan time.Time
+	var timeoutTimer *time.Timer
+	if timeout > 0 {
+		timeoutTimer = time.NewTimer(timeout)
+		timeoutC = timeoutTimer.C
+		defer timeoutTimer.Stop()
+	}
+
+	for {
+		select {
+		case <-ticker.C:
+			if connectToDocker() {
+				return true, false
+			}
+		case <-timeoutC:
+			return false, false
+		case <-d.closeRetry:
+			return false, true
+		}
+	}
 }
 
 func lazyCgroupCacheInit(d *addDockerMetadata) {

--- a/libbeat/processors/add_docker_metadata/add_docker_metadata_test.go
+++ b/libbeat/processors/add_docker_metadata/add_docker_metadata_test.go
@@ -526,19 +526,7 @@ func TestConfigValidate(t *testing.T) {
 	}
 }
 
-func withDockerMetadataRetryInterval(t *testing.T, interval time.Duration) {
-	t.Helper()
-
-	previous := dockerMetadataRetryInterval
-	dockerMetadataRetryInterval = interval
-	t.Cleanup(func() {
-		dockerMetadataRetryInterval = previous
-	})
-}
-
 func TestInitializationRetriesConnectionToDocker(t *testing.T) {
-	withDockerMetadataRetryInterval(t, time.Millisecond)
-
 	var attempts atomic.Int32
 	watcherConstructor := func(_ *logp.Logger, host string, tls *docker.TLSConfig, shortID bool) (docker.Watcher, error) {
 		attempt := attempts.Add(1)
@@ -558,8 +546,9 @@ func TestInitializationRetriesConnectionToDocker(t *testing.T) {
 	}
 
 	testConfig := config.MustNewConfigFrom(map[string]any{
-		"match_fields":              []string{"foo"},
-		"wait_for_metadata_timeout": "1s",
+		"match_fields":                   []string{"foo"},
+		"wait_for_metadata_retry_period": "1ms",
+		"wait_for_metadata_timeout":      "1s",
 	})
 
 	p, err := buildDockerMetadataProcessor(logp.NewNopLogger(), testConfig, watcherConstructor)
@@ -581,8 +570,6 @@ func TestInitializationRetriesConnectionToDocker(t *testing.T) {
 }
 
 func TestInitializationRetriesUntilTimeout(t *testing.T) {
-	withDockerMetadataRetryInterval(t, time.Millisecond)
-
 	var attempts atomic.Int32
 	watcherConstructor := func(_ *logp.Logger, host string, tls *docker.TLSConfig, shortID bool) (docker.Watcher, error) {
 		attempts.Add(1)
@@ -590,8 +577,9 @@ func TestInitializationRetriesUntilTimeout(t *testing.T) {
 	}
 
 	testConfig := config.MustNewConfigFrom(map[string]any{
-		"match_fields":              []string{"foo"},
-		"wait_for_metadata_timeout": "10ms",
+		"match_fields":                   []string{"foo"},
+		"wait_for_metadata_retry_period": "1ms",
+		"wait_for_metadata_timeout":      "10ms",
 	})
 
 	p, err := buildDockerMetadataProcessor(logp.NewNopLogger(), testConfig, watcherConstructor)
@@ -616,8 +604,6 @@ func TestInitializationRetriesUntilTimeout(t *testing.T) {
 }
 
 func TestInitializationRetriesIndefinitelyWithZeroTimeout(t *testing.T) {
-	withDockerMetadataRetryInterval(t, time.Millisecond)
-
 	var attempts atomic.Int32
 	watcherConstructor := func(_ *logp.Logger, host string, tls *docker.TLSConfig, shortID bool) (docker.Watcher, error) {
 		attempts.Add(1)
@@ -625,7 +611,8 @@ func TestInitializationRetriesIndefinitelyWithZeroTimeout(t *testing.T) {
 	}
 
 	testConfig := config.MustNewConfigFrom(map[string]any{
-		"wait_for_metadata_timeout": "0s",
+		"wait_for_metadata_retry_period": "1ms",
+		"wait_for_metadata_timeout":      "0s",
 	})
 
 	p, err := buildDockerMetadataProcessor(logp.NewNopLogger(), testConfig, watcherConstructor)
@@ -642,8 +629,6 @@ func TestInitializationRetriesIndefinitelyWithZeroTimeout(t *testing.T) {
 }
 
 func TestInitializationWaitsForMetadata(t *testing.T) {
-	withDockerMetadataRetryInterval(t, time.Millisecond)
-
 	var attempts atomic.Int32
 	watcherConstructor := func(_ *logp.Logger, host string, tls *docker.TLSConfig, shortID bool) (docker.Watcher, error) {
 		attempt := attempts.Add(1)
@@ -663,9 +648,10 @@ func TestInitializationWaitsForMetadata(t *testing.T) {
 	}
 
 	testConfig := config.MustNewConfigFrom(map[string]any{
-		"match_fields":              []string{"foo"},
-		"wait_for_metadata":         true,
-		"wait_for_metadata_timeout": "1s",
+		"match_fields":                   []string{"foo"},
+		"wait_for_metadata":              true,
+		"wait_for_metadata_retry_period": "1ms",
+		"wait_for_metadata_timeout":      "1s",
 	})
 
 	p, err := buildDockerMetadataProcessor(logp.NewNopLogger(), testConfig, watcherConstructor)
@@ -683,8 +669,6 @@ func TestInitializationWaitsForMetadata(t *testing.T) {
 }
 
 func TestInitializationWaitForMetadataReturnsErrorOnTimeout(t *testing.T) {
-	withDockerMetadataRetryInterval(t, time.Millisecond)
-
 	var attempts atomic.Int32
 	watcherConstructor := func(_ *logp.Logger, host string, tls *docker.TLSConfig, shortID bool) (docker.Watcher, error) {
 		attempts.Add(1)
@@ -692,8 +676,9 @@ func TestInitializationWaitForMetadataReturnsErrorOnTimeout(t *testing.T) {
 	}
 
 	testConfig := config.MustNewConfigFrom(map[string]any{
-		"wait_for_metadata":         true,
-		"wait_for_metadata_timeout": "10ms",
+		"wait_for_metadata":              true,
+		"wait_for_metadata_retry_period": "1ms",
+		"wait_for_metadata_timeout":      "10ms",
 	})
 
 	p, err := buildDockerMetadataProcessor(logp.NewNopLogger(), testConfig, watcherConstructor)

--- a/libbeat/processors/add_docker_metadata/add_docker_metadata_test.go
+++ b/libbeat/processors/add_docker_metadata/add_docker_metadata_test.go
@@ -110,6 +110,9 @@ func TestInitializationNoDocker(t *testing.T) {
 
 	p, err := buildDockerMetadataProcessor(logp.L(), testConfig, docker.NewWatcher)
 	assert.NoError(t, err, "initializing add_docker_metadata processor")
+	t.Cleanup(func() {
+		assert.NoError(t, processors.Close(p), "closing add_docker_metadata processor")
+	})
 
 	input := mapstr.M{}
 	result, err := p.Run(&beat.Event{Fields: input})
@@ -453,6 +456,9 @@ func TestWatcherError(t *testing.T) {
 
 	p, err := buildDockerMetadataProcessor(logger, testConfig, MockWatcherFactory(nil, errors.New("mock error")))
 	assert.NoError(t, err, "initializing add_docker_metadata processor")
+	t.Cleanup(func() {
+		assert.NoError(t, processors.Close(p), "closing add_docker_metadata processor")
+	})
 	assert.Len(t, observedLogs.FilterMessageSnippet("unable to start the docker watcher").TakeAll(), 1)
 
 	input := mapstr.M{
@@ -463,7 +469,76 @@ func TestWatcherError(t *testing.T) {
 	assert.Equal(t, mapstr.M{"field": "value"}, result.Fields)
 }
 
+func TestConfigValidate(t *testing.T) {
+	tests := []struct {
+		name      string
+		cfg       map[string]any
+		expectErr bool
+	}{
+		{
+			name: "default",
+			cfg:  map[string]any{},
+		},
+		{
+			name: "valid wait timeout",
+			cfg: map[string]any{
+				"wait_for_metadata":         true,
+				"wait_for_metadata_timeout": "20s",
+			},
+		},
+		{
+			name: "zero wait timeout",
+			cfg: map[string]any{
+				"wait_for_metadata":         true,
+				"wait_for_metadata_timeout": "0s",
+			},
+		},
+		{
+			name: "invalid wait timeout",
+			cfg: map[string]any{
+				"wait_for_metadata":         true,
+				"wait_for_metadata_timeout": "invalid_duration",
+			},
+			expectErr: true,
+		},
+		{
+			name: "negative wait timeout",
+			cfg: map[string]any{
+				"wait_for_metadata":         true,
+				"wait_for_metadata_timeout": "-1s",
+			},
+			expectErr: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			cfg := config.MustNewConfigFrom(test.cfg)
+			c := defaultConfig()
+
+			err := cfg.Unpack(&c)
+			if test.expectErr {
+				require.Error(t, err, "config unpack should fail")
+			} else {
+				require.NoError(t, err, "config unpack should succeed")
+			}
+		})
+	}
+}
+
+func withDockerMetadataRetryInterval(t *testing.T, interval time.Duration) {
+	t.Helper()
+
+	previous := dockerMetadataRetryInterval
+	dockerMetadataRetryInterval = interval
+	t.Cleanup(func() {
+		dockerMetadataRetryInterval = previous
+	})
+}
+
 func TestInitializationRetriesConnectionToDocker(t *testing.T) {
+	withDockerMetadataRetryInterval(t, time.Millisecond)
+
 	var attempts atomic.Int32
 	watcherConstructor := func(_ *logp.Logger, host string, tls *docker.TLSConfig, shortID bool) (docker.Watcher, error) {
 		attempt := attempts.Add(1)
@@ -484,7 +559,7 @@ func TestInitializationRetriesConnectionToDocker(t *testing.T) {
 
 	testConfig := config.MustNewConfigFrom(map[string]any{
 		"match_fields":              []string{"foo"},
-		"connection_retry_interval": "1ms",
+		"wait_for_metadata_timeout": "1s",
 	})
 
 	p, err := buildDockerMetadataProcessor(logp.NewNopLogger(), testConfig, watcherConstructor)
@@ -505,7 +580,9 @@ func TestInitializationRetriesConnectionToDocker(t *testing.T) {
 	assert.GreaterOrEqual(t, attempts.Load(), int32(2), "watcher constructor should be called more than once")
 }
 
-func TestInitializationDoesNotRetryWhenDisabled(t *testing.T) {
+func TestInitializationRetriesUntilTimeout(t *testing.T) {
+	withDockerMetadataRetryInterval(t, time.Millisecond)
+
 	var attempts atomic.Int32
 	watcherConstructor := func(_ *logp.Logger, host string, tls *docker.TLSConfig, shortID bool) (docker.Watcher, error) {
 		attempts.Add(1)
@@ -514,7 +591,7 @@ func TestInitializationDoesNotRetryWhenDisabled(t *testing.T) {
 
 	testConfig := config.MustNewConfigFrom(map[string]any{
 		"match_fields":              []string{"foo"},
-		"connection_retry_interval": 0,
+		"wait_for_metadata_timeout": "10ms",
 	})
 
 	p, err := buildDockerMetadataProcessor(logp.NewNopLogger(), testConfig, watcherConstructor)
@@ -523,12 +600,106 @@ func TestInitializationDoesNotRetryWhenDisabled(t *testing.T) {
 		assert.NoError(t, processors.Close(p), "closing add_docker_metadata processor")
 	})
 
-	time.Sleep(20 * time.Millisecond)
-	assert.EqualValues(t, 1, attempts.Load(), "watcher constructor should not be retried when interval is disabled")
+	assert.Eventually(t, func() bool {
+		return attempts.Load() > 1
+	}, time.Second, time.Millisecond, "watcher constructor should be retried until timeout")
+
+	assert.Eventually(t, func() bool {
+		previous := attempts.Load()
+		time.Sleep(20 * time.Millisecond)
+		return previous == attempts.Load()
+	}, time.Second, 25*time.Millisecond, "watcher constructor should stop being called after timeout")
 
 	result, runErr := p.Run(&beat.Event{Fields: mapstr.M{"foo": "container_id"}})
 	require.NoError(t, runErr, "processing an event")
 	assert.Equal(t, mapstr.M{"foo": "container_id"}, result.Fields, "event must remain unchanged without docker connection")
+}
+
+func TestInitializationRetriesIndefinitelyWithZeroTimeout(t *testing.T) {
+	withDockerMetadataRetryInterval(t, time.Millisecond)
+
+	var attempts atomic.Int32
+	watcherConstructor := func(_ *logp.Logger, host string, tls *docker.TLSConfig, shortID bool) (docker.Watcher, error) {
+		attempts.Add(1)
+		return nil, errors.New("docker unavailable")
+	}
+
+	testConfig := config.MustNewConfigFrom(map[string]any{
+		"wait_for_metadata_timeout": "0s",
+	})
+
+	p, err := buildDockerMetadataProcessor(logp.NewNopLogger(), testConfig, watcherConstructor)
+	require.NoError(t, err, "initializing add_docker_metadata processor")
+
+	assert.Eventually(t, func() bool {
+		return attempts.Load() > 2
+	}, time.Second, time.Millisecond, "watcher constructor should keep being retried when timeout is zero")
+
+	require.NoError(t, processors.Close(p), "closing add_docker_metadata processor")
+	previous := attempts.Load()
+	time.Sleep(20 * time.Millisecond)
+	assert.Equal(t, previous, attempts.Load(), "watcher constructor should stop being retried after close")
+}
+
+func TestInitializationWaitsForMetadata(t *testing.T) {
+	withDockerMetadataRetryInterval(t, time.Millisecond)
+
+	var attempts atomic.Int32
+	watcherConstructor := func(_ *logp.Logger, host string, tls *docker.TLSConfig, shortID bool) (docker.Watcher, error) {
+		attempt := attempts.Add(1)
+		if attempt == 1 {
+			return nil, errors.New("docker unavailable")
+		}
+
+		return &mockWatcher{
+			containers: map[string]*docker.Container{
+				"container_id": {
+					ID:    "container_id",
+					Image: "image",
+					Name:  "name",
+				},
+			},
+		}, nil
+	}
+
+	testConfig := config.MustNewConfigFrom(map[string]any{
+		"match_fields":              []string{"foo"},
+		"wait_for_metadata":         true,
+		"wait_for_metadata_timeout": "1s",
+	})
+
+	p, err := buildDockerMetadataProcessor(logp.NewNopLogger(), testConfig, watcherConstructor)
+	require.NoError(t, err, "initializing add_docker_metadata processor")
+	t.Cleanup(func() {
+		assert.NoError(t, processors.Close(p), "closing add_docker_metadata processor")
+	})
+
+	result, runErr := p.Run(&beat.Event{Fields: mapstr.M{"foo": "container_id"}})
+	require.NoError(t, runErr, "processing an event")
+	containerID, getErr := result.Fields.GetValue("container.id")
+	require.NoError(t, getErr, "container metadata should be available immediately after startup")
+	assert.Equal(t, "container_id", containerID, "processor should enrich events after synchronous retry connects to docker")
+	assert.GreaterOrEqual(t, attempts.Load(), int32(2), "watcher constructor should be called more than once")
+}
+
+func TestInitializationWaitForMetadataReturnsErrorOnTimeout(t *testing.T) {
+	withDockerMetadataRetryInterval(t, time.Millisecond)
+
+	var attempts atomic.Int32
+	watcherConstructor := func(_ *logp.Logger, host string, tls *docker.TLSConfig, shortID bool) (docker.Watcher, error) {
+		attempts.Add(1)
+		return nil, errors.New("docker unavailable")
+	}
+
+	testConfig := config.MustNewConfigFrom(map[string]any{
+		"wait_for_metadata":         true,
+		"wait_for_metadata_timeout": "10ms",
+	})
+
+	p, err := buildDockerMetadataProcessor(logp.NewNopLogger(), testConfig, watcherConstructor)
+	require.Error(t, err, "initializing add_docker_metadata processor should fail after timeout")
+	assert.Nil(t, p, "processor should not be returned after wait_for_metadata timeout")
+	assert.Greater(t, attempts.Load(), int32(1), "watcher constructor should be retried before timeout")
 }
 
 // Mock container watcher

--- a/libbeat/processors/add_docker_metadata/config.go
+++ b/libbeat/processors/add_docker_metadata/config.go
@@ -20,6 +20,7 @@
 package add_docker_metadata
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/elastic/elastic-agent-autodiscover/docker"
@@ -27,16 +28,17 @@ import (
 
 // Config for docker processor.
 type Config struct {
-	Host                    string            `config:"host"`                      // Docker socket (UNIX or TCP socket).
-	TLS                     *docker.TLSConfig `config:"ssl"`                       // TLS settings for connecting to Docker.
-	Fields                  []string          `config:"match_fields"`              // A list of fields to match a container ID.
-	MatchSource             bool              `config:"match_source"`              // Match container ID from a log path present in source field.
-	MatchShortID            bool              `config:"match_short_id"`            // Match to container short ID from a log path present in source field.
-	SourceIndex             int               `config:"match_source_index"`        // Index in the source path split by / to look for container ID.
-	MatchPIDs               []string          `config:"match_pids"`                // A list of fields containing process IDs (PIDs).
-	HostFS                  string            `config:"hostfs"`                    // Specifies the mount point of the host’s filesystem for use in monitoring a host from within a container.
-	DeDot                   bool              `config:"labels.dedot"`              // If set to true, replace dots in labels with `_`.
-	ConnectionRetryInterval time.Duration     `config:"connection_retry_interval"` // Interval to retry connecting to Docker
+	Host                string            `config:"host"`                      // Docker socket (UNIX or TCP socket).
+	TLS                 *docker.TLSConfig `config:"ssl"`                       // TLS settings for connecting to Docker.
+	Fields              []string          `config:"match_fields"`              // A list of fields to match a container ID.
+	MatchSource         bool              `config:"match_source"`              // Match container ID from a log path present in source field.
+	MatchShortID        bool              `config:"match_short_id"`            // Match to container short ID from a log path present in source field.
+	SourceIndex         int               `config:"match_source_index"`        // Index in the source path split by / to look for container ID.
+	MatchPIDs           []string          `config:"match_pids"`                // A list of fields containing process IDs (PIDs).
+	HostFS              string            `config:"hostfs"`                    // Specifies the mount point of the host’s filesystem for use in monitoring a host from within a container.
+	DeDot               bool              `config:"labels.dedot"`              // If set to true, replace dots in labels with `_`.
+	WaitMetadata        bool              `config:"wait_for_metadata"`         // Block initialization until Docker metadata is available.
+	WaitMetadataTimeout time.Duration     `config:"wait_for_metadata_timeout"` // Maximum time to wait for Docker metadata.
 
 	// Annotations are kept after container is killed, until they haven't been
 	// accessed for a full `cleanup_timeout`:
@@ -45,11 +47,20 @@ type Config struct {
 
 func defaultConfig() Config {
 	return Config{
-		Host:                    "unix:///var/run/docker.sock",
-		MatchSource:             true,
-		SourceIndex:             4, // Use 4 to match the CID in /var/lib/docker/containers/<container_id>/*.log.
-		MatchPIDs:               []string{"process.pid", "process.parent.pid"},
-		DeDot:                   true,
-		ConnectionRetryInterval: time.Second * 10,
+		Host:                "unix:///var/run/docker.sock",
+		MatchSource:         true,
+		SourceIndex:         4, // Use 4 to match the CID in /var/lib/docker/containers/<container_id>/*.log.
+		MatchPIDs:           []string{"process.pid", "process.parent.pid"},
+		DeDot:               true,
+		WaitMetadata:        false,
+		WaitMetadataTimeout: 30 * time.Second,
 	}
+}
+
+func (c Config) Validate() error {
+	if c.WaitMetadataTimeout < 0 {
+		return fmt.Errorf("wait_for_metadata_timeout must be zero or greater (zero means wait indefinitely)")
+	}
+
+	return nil
 }

--- a/libbeat/processors/add_docker_metadata/config.go
+++ b/libbeat/processors/add_docker_metadata/config.go
@@ -28,17 +28,18 @@ import (
 
 // Config for docker processor.
 type Config struct {
-	Host                string            `config:"host"`                      // Docker socket (UNIX or TCP socket).
-	TLS                 *docker.TLSConfig `config:"ssl"`                       // TLS settings for connecting to Docker.
-	Fields              []string          `config:"match_fields"`              // A list of fields to match a container ID.
-	MatchSource         bool              `config:"match_source"`              // Match container ID from a log path present in source field.
-	MatchShortID        bool              `config:"match_short_id"`            // Match to container short ID from a log path present in source field.
-	SourceIndex         int               `config:"match_source_index"`        // Index in the source path split by / to look for container ID.
-	MatchPIDs           []string          `config:"match_pids"`                // A list of fields containing process IDs (PIDs).
-	HostFS              string            `config:"hostfs"`                    // Specifies the mount point of the host’s filesystem for use in monitoring a host from within a container.
-	DeDot               bool              `config:"labels.dedot"`              // If set to true, replace dots in labels with `_`.
-	WaitMetadata        bool              `config:"wait_for_metadata"`         // Block initialization until Docker metadata is available.
-	WaitMetadataTimeout time.Duration     `config:"wait_for_metadata_timeout"` // Maximum time to wait for Docker metadata.
+	Host                string            `config:"host"`                           // Docker socket (UNIX or TCP socket).
+	TLS                 *docker.TLSConfig `config:"ssl"`                            // TLS settings for connecting to Docker.
+	Fields              []string          `config:"match_fields"`                   // A list of fields to match a container ID.
+	MatchSource         bool              `config:"match_source"`                   // Match container ID from a log path present in source field.
+	MatchShortID        bool              `config:"match_short_id"`                 // Match to container short ID from a log path present in source field.
+	SourceIndex         int               `config:"match_source_index"`             // Index in the source path split by / to look for container ID.
+	MatchPIDs           []string          `config:"match_pids"`                     // A list of fields containing process IDs (PIDs).
+	HostFS              string            `config:"hostfs"`                         // Specifies the mount point of the host’s filesystem for use in monitoring a host from within a container.
+	DeDot               bool              `config:"labels.dedot"`                   // If set to true, replace dots in labels with `_`.
+	WaitMetadata        bool              `config:"wait_for_metadata"`              // Block initialization until Docker metadata is available.
+	WaitMetadataTimeout time.Duration     `config:"wait_for_metadata_timeout"`      // Maximum time to wait for Docker metadata.
+	WaitMetadataRetry   time.Duration     `config:"wait_for_metadata_retry_period"` // How long to wait between retries.
 
 	// Annotations are kept after container is killed, until they haven't been
 	// accessed for a full `cleanup_timeout`:
@@ -54,6 +55,7 @@ func defaultConfig() Config {
 		DeDot:               true,
 		WaitMetadata:        false,
 		WaitMetadataTimeout: 30 * time.Second,
+		WaitMetadataRetry:   10 * time.Second,
 	}
 }
 

--- a/metricbeat/metricbeat.reference.yml
+++ b/metricbeat/metricbeat.reference.yml
@@ -1313,6 +1313,7 @@ metricbeat.modules:
 #      labels.dedot: false
 #      wait_for_metadata: false
 #      wait_for_metadata_timeout: 30s
+#      wait_for_metadata_retry_period: 10s
 #      # To connect to Docker over TLS you must specify a client and CA certificate.
 #      #ssl:
 #      #  certificate_authority: "/etc/pki/root/ca.pem"

--- a/metricbeat/metricbeat.reference.yml
+++ b/metricbeat/metricbeat.reference.yml
@@ -1311,7 +1311,8 @@ metricbeat.modules:
 #      match_short_id: false
 #      cleanup_timeout: 60
 #      labels.dedot: false
-#      connection_retry_interval: 10s
+#      wait_for_metadata: false
+#      wait_for_metadata_timeout: 30s
 #      # To connect to Docker over TLS you must specify a client and CA certificate.
 #      #ssl:
 #      #  certificate_authority: "/etc/pki/root/ca.pem"

--- a/packetbeat/packetbeat.reference.yml
+++ b/packetbeat/packetbeat.reference.yml
@@ -811,7 +811,8 @@ packetbeat.ignore_outgoing: false
 #      match_short_id: false
 #      cleanup_timeout: 60
 #      labels.dedot: false
-#      connection_retry_interval: 10s
+#      wait_for_metadata: false
+#      wait_for_metadata_timeout: 30s
 #      # To connect to Docker over TLS you must specify a client and CA certificate.
 #      #ssl:
 #      #  certificate_authority: "/etc/pki/root/ca.pem"

--- a/packetbeat/packetbeat.reference.yml
+++ b/packetbeat/packetbeat.reference.yml
@@ -813,6 +813,7 @@ packetbeat.ignore_outgoing: false
 #      labels.dedot: false
 #      wait_for_metadata: false
 #      wait_for_metadata_timeout: 30s
+#      wait_for_metadata_retry_period: 10s
 #      # To connect to Docker over TLS you must specify a client and CA certificate.
 #      #ssl:
 #      #  certificate_authority: "/etc/pki/root/ca.pem"

--- a/winlogbeat/winlogbeat.reference.yml
+++ b/winlogbeat/winlogbeat.reference.yml
@@ -219,7 +219,8 @@ winlogbeat.event_logs:
 #      match_short_id: false
 #      cleanup_timeout: 60
 #      labels.dedot: false
-#      connection_retry_interval: 10s
+#      wait_for_metadata: false
+#      wait_for_metadata_timeout: 30s
 #      # To connect to Docker over TLS you must specify a client and CA certificate.
 #      #ssl:
 #      #  certificate_authority: "/etc/pki/root/ca.pem"

--- a/winlogbeat/winlogbeat.reference.yml
+++ b/winlogbeat/winlogbeat.reference.yml
@@ -221,6 +221,7 @@ winlogbeat.event_logs:
 #      labels.dedot: false
 #      wait_for_metadata: false
 #      wait_for_metadata_timeout: 30s
+#      wait_for_metadata_retry_period: 10s
 #      # To connect to Docker over TLS you must specify a client and CA certificate.
 #      #ssl:
 #      #  certificate_authority: "/etc/pki/root/ca.pem"

--- a/x-pack/auditbeat/auditbeat.reference.yml
+++ b/x-pack/auditbeat/auditbeat.reference.yml
@@ -409,6 +409,7 @@ auditbeat.modules:
 #      labels.dedot: false
 #      wait_for_metadata: false
 #      wait_for_metadata_timeout: 30s
+#      wait_for_metadata_retry_period: 10s
 #      # To connect to Docker over TLS you must specify a client and CA certificate.
 #      #ssl:
 #      #  certificate_authority: "/etc/pki/root/ca.pem"

--- a/x-pack/auditbeat/auditbeat.reference.yml
+++ b/x-pack/auditbeat/auditbeat.reference.yml
@@ -407,7 +407,8 @@ auditbeat.modules:
 #      match_short_id: false
 #      cleanup_timeout: 60
 #      labels.dedot: false
-#      connection_retry_interval: 10s
+#      wait_for_metadata: false
+#      wait_for_metadata_timeout: 30s
 #      # To connect to Docker over TLS you must specify a client and CA certificate.
 #      #ssl:
 #      #  certificate_authority: "/etc/pki/root/ca.pem"

--- a/x-pack/filebeat/filebeat.reference.yml
+++ b/x-pack/filebeat/filebeat.reference.yml
@@ -3559,7 +3559,8 @@ filebeat.inputs:
 #      match_short_id: false
 #      cleanup_timeout: 60
 #      labels.dedot: false
-#      connection_retry_interval: 10s
+#      wait_for_metadata: false
+#      wait_for_metadata_timeout: 30s
 #      # To connect to Docker over TLS you must specify a client and CA certificate.
 #      #ssl:
 #      #  certificate_authority: "/etc/pki/root/ca.pem"

--- a/x-pack/filebeat/filebeat.reference.yml
+++ b/x-pack/filebeat/filebeat.reference.yml
@@ -3561,6 +3561,7 @@ filebeat.inputs:
 #      labels.dedot: false
 #      wait_for_metadata: false
 #      wait_for_metadata_timeout: 30s
+#      wait_for_metadata_retry_period: 10s
 #      # To connect to Docker over TLS you must specify a client and CA certificate.
 #      #ssl:
 #      #  certificate_authority: "/etc/pki/root/ca.pem"

--- a/x-pack/heartbeat/heartbeat.reference.yml
+++ b/x-pack/heartbeat/heartbeat.reference.yml
@@ -428,6 +428,7 @@ heartbeat.jobs:
 #      labels.dedot: false
 #      wait_for_metadata: false
 #      wait_for_metadata_timeout: 30s
+#      wait_for_metadata_retry_period: 10s
 #      # To connect to Docker over TLS you must specify a client and CA certificate.
 #      #ssl:
 #      #  certificate_authority: "/etc/pki/root/ca.pem"

--- a/x-pack/heartbeat/heartbeat.reference.yml
+++ b/x-pack/heartbeat/heartbeat.reference.yml
@@ -426,7 +426,8 @@ heartbeat.jobs:
 #      match_short_id: false
 #      cleanup_timeout: 60
 #      labels.dedot: false
-#      connection_retry_interval: 10s
+#      wait_for_metadata: false
+#      wait_for_metadata_timeout: 30s
 #      # To connect to Docker over TLS you must specify a client and CA certificate.
 #      #ssl:
 #      #  certificate_authority: "/etc/pki/root/ca.pem"

--- a/x-pack/metricbeat/metricbeat.reference.yml
+++ b/x-pack/metricbeat/metricbeat.reference.yml
@@ -1978,7 +1978,8 @@ metricbeat.modules:
 #      match_short_id: false
 #      cleanup_timeout: 60
 #      labels.dedot: false
-#      connection_retry_interval: 10s
+#      wait_for_metadata: false
+#      wait_for_metadata_timeout: 30s
 #      # To connect to Docker over TLS you must specify a client and CA certificate.
 #      #ssl:
 #      #  certificate_authority: "/etc/pki/root/ca.pem"

--- a/x-pack/metricbeat/metricbeat.reference.yml
+++ b/x-pack/metricbeat/metricbeat.reference.yml
@@ -1980,6 +1980,7 @@ metricbeat.modules:
 #      labels.dedot: false
 #      wait_for_metadata: false
 #      wait_for_metadata_timeout: 30s
+#      wait_for_metadata_retry_period: 10s
 #      # To connect to Docker over TLS you must specify a client and CA certificate.
 #      #ssl:
 #      #  certificate_authority: "/etc/pki/root/ca.pem"

--- a/x-pack/osquerybeat/osquerybeat.reference.yml
+++ b/x-pack/osquerybeat/osquerybeat.reference.yml
@@ -221,6 +221,7 @@ seccomp.enabled: false
 #      labels.dedot: false
 #      wait_for_metadata: false
 #      wait_for_metadata_timeout: 30s
+#      wait_for_metadata_retry_period: 10s
 #      # To connect to Docker over TLS you must specify a client and CA certificate.
 #      #ssl:
 #      #  certificate_authority: "/etc/pki/root/ca.pem"

--- a/x-pack/osquerybeat/osquerybeat.reference.yml
+++ b/x-pack/osquerybeat/osquerybeat.reference.yml
@@ -219,7 +219,8 @@ seccomp.enabled: false
 #      match_short_id: false
 #      cleanup_timeout: 60
 #      labels.dedot: false
-#      connection_retry_interval: 10s
+#      wait_for_metadata: false
+#      wait_for_metadata_timeout: 30s
 #      # To connect to Docker over TLS you must specify a client and CA certificate.
 #      #ssl:
 #      #  certificate_authority: "/etc/pki/root/ca.pem"

--- a/x-pack/packetbeat/packetbeat.reference.yml
+++ b/x-pack/packetbeat/packetbeat.reference.yml
@@ -811,7 +811,8 @@ packetbeat.ignore_outgoing: false
 #      match_short_id: false
 #      cleanup_timeout: 60
 #      labels.dedot: false
-#      connection_retry_interval: 10s
+#      wait_for_metadata: false
+#      wait_for_metadata_timeout: 30s
 #      # To connect to Docker over TLS you must specify a client and CA certificate.
 #      #ssl:
 #      #  certificate_authority: "/etc/pki/root/ca.pem"

--- a/x-pack/packetbeat/packetbeat.reference.yml
+++ b/x-pack/packetbeat/packetbeat.reference.yml
@@ -813,6 +813,7 @@ packetbeat.ignore_outgoing: false
 #      labels.dedot: false
 #      wait_for_metadata: false
 #      wait_for_metadata_timeout: 30s
+#      wait_for_metadata_retry_period: 10s
 #      # To connect to Docker over TLS you must specify a client and CA certificate.
 #      #ssl:
 #      #  certificate_authority: "/etc/pki/root/ca.pem"

--- a/x-pack/winlogbeat/winlogbeat.reference.yml
+++ b/x-pack/winlogbeat/winlogbeat.reference.yml
@@ -221,7 +221,8 @@ winlogbeat.event_logs:
 #      match_short_id: false
 #      cleanup_timeout: 60
 #      labels.dedot: false
-#      connection_retry_interval: 10s
+#      wait_for_metadata: false
+#      wait_for_metadata_timeout: 30s
 #      # To connect to Docker over TLS you must specify a client and CA certificate.
 #      #ssl:
 #      #  certificate_authority: "/etc/pki/root/ca.pem"

--- a/x-pack/winlogbeat/winlogbeat.reference.yml
+++ b/x-pack/winlogbeat/winlogbeat.reference.yml
@@ -223,6 +223,7 @@ winlogbeat.event_logs:
 #      labels.dedot: false
 #      wait_for_metadata: false
 #      wait_for_metadata_timeout: 30s
+#      wait_for_metadata_retry_period: 10s
 #      # To connect to Docker over TLS you must specify a client and CA certificate.
 #      #ssl:
 #      #  certificate_authority: "/etc/pki/root/ca.pem"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Proposed commit message

Configure Docker metadata wait behavior

Replace the branch-only `connection_retry_interval` setting with `wait_for_metadata` and `wait_for_metadata_timeout` so `add_docker_metadata` matches the `add_kubernetes_metadata` startup behavior from elastic/beats#50509. By default retries remain asynchronous and bounded by the timeout; setting `wait_for_metadata` blocks startup and returns an error if Docker metadata is unavailable before the timeout.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).

## Disruptive User Impact

None for released behavior. This updates the in-branch Docker retry configuration to use `wait_for_metadata` and `wait_for_metadata_timeout` before it ships.

## How to test this PR locally

```bash
go test -v ./libbeat/processors/add_docker_metadata
go test -race -v ./libbeat/processors/add_docker_metadata
```

## Related issues

- Relates https://github.com/elastic/beats/pull/50509

## Use cases

- Users can keep default asynchronous Docker metadata startup retries with a bounded timeout.
- Users can set `wait_for_metadata: true` to fail startup if Docker metadata is unavailable before `wait_for_metadata_timeout`.
- Users can set `wait_for_metadata_timeout: 0` to retry Docker metadata connection indefinitely.

## Screenshots

N/A

## Logs

N/A
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-13f6cdef-8f57-435c-a18d-97459ff93633"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-13f6cdef-8f57-435c-a18d-97459ff93633"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

