### PR TITLE
Fix golangci-lint warnings in filestream scanner metrics PR

### DIFF
--- a/filebeat/input/filestream/fswatch_test.go
+++ b/filebeat/input/filestream/fswatch_test.go
@@ -608,6 +608,7 @@ func copyFile(t *testing.T, from, to string) {
 
 	content, err := os.ReadFile(from)
 	require.NoError(t, err, "failed to read source file %q", from)
+	//nolint:gosec // G703: from and to are test fixture paths under t.TempDir()
 	require.NoError(t, os.WriteFile(to, content, 0o600), "failed to write destination file %q", to)
 }
 

--- a/filebeat/input/filestream/internal/input-logfile/manager_test.go
+++ b/filebeat/input/filestream/internal/input-logfile/manager_test.go
@@ -18,7 +18,6 @@
 package input_logfile
 
 import (
-	"bytes"
 	"errors"
 	"fmt"
 	"strings"
@@ -27,14 +26,14 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/zap"
-	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
 
 	v2 "github.com/elastic/beats/v7/filebeat/input/v2"
 	"github.com/elastic/beats/v7/libbeat/statestore"
 	"github.com/elastic/beats/v7/libbeat/statestore/storetest"
 	"github.com/elastic/elastic-agent-libs/config"
 	"github.com/elastic/elastic-agent-libs/logp"
+	"github.com/elastic/elastic-agent-libs/logp/logptest"
 )
 
 const testPluginName = "my_test_plugin"
@@ -191,7 +190,7 @@ func TestInputManager_Create(t *testing.T) {
 			testStore, err := storeReg.Get("test")
 			require.NoError(t, err)
 
-			log, buff := newBufferLogger()
+			log, observedLogs := logptest.NewTestingLoggerWithObserver(t, "")
 
 			cim := &InputManager{
 				Logger:     log,
@@ -214,10 +213,11 @@ func TestInputManager_Create(t *testing.T) {
 			err = cim.Delete(cfg)
 			require.NoError(t, err)
 
-			assert.NotContains(t, buff.String(),
-				"filestream input with ID")
-			assert.NotContains(t, buff.String(),
-				"already exists")
+			assert.False(t, observedLogsContain(observedLogs,
+				"filestream input with ID"),
+				"unexpected duplicated ID warning in logs")
+			assert.False(t, observedLogsContain(observedLogs, "already exists"),
+				"unexpected duplicated ID warning in logs")
 		})
 
 	t.Run("does not start an input with duplicated ID", func(t *testing.T) {
@@ -235,7 +235,7 @@ func TestInputManager_Create(t *testing.T) {
 				testStore, err := storeReg.Get("test")
 				require.NoError(t, err)
 
-				log, buff := newBufferLogger()
+				log, observedLogs := logptest.NewTestingLoggerWithObserver(t, "")
 
 				cim := &InputManager{
 					Logger:     log,
@@ -269,10 +269,9 @@ paths:
 				_, err = cim.Create(cfg2)
 				require.Error(t, err, "filestream should not have created an input with a duplicated ID")
 
-				logs := buff.String()
-				// Assert the logs contain the correct log message
-				assert.Contains(t, logs,
-					fmt.Sprintf("filestream input ID '%s' is duplicated:", tc.id))
+				assert.True(t, observedLogsContain(observedLogs,
+					fmt.Sprintf("filestream input ID '%s' is duplicated:", tc.id)),
+					"duplicated ID warning not found in logs")
 
 				// Assert the error contains the correct text
 				assert.Contains(t, err.Error(),
@@ -286,7 +285,7 @@ paths:
 		testStore, err := storeReg.Get("test")
 		require.NoError(t, err)
 
-		log, _ := newBufferLogger()
+		log := logptest.NewTestingLogger(t, "")
 
 		cim := &InputManager{
 			Logger:     log,
@@ -384,7 +383,7 @@ paths:
 		testStore, err := storeReg.Get("test")
 		require.NoError(t, err)
 
-		log, buff := newBufferLogger()
+		log, observedLogs := logptest.NewTestingLoggerWithObserver(t, "")
 
 		cim := &InputManager{
 			Logger:     log,
@@ -418,25 +417,21 @@ paths:
 		_, err = cim.Create(cfg2)
 		require.NoError(t, err, "filestream should not have created an input with a duplicated ID")
 
-		logs := buff.String()
-		// Assert the logs contain the correct log message
-		assert.Contains(t, logs,
+		assert.True(t, observedLogsContain(observedLogs,
 			"filestream input with ID 'duplicated-id' already exists, this "+
 				"will lead to data duplication, please use a different ID. Metrics "+
-				"collection has been disabled on this input.",
+				"collection has been disabled on this input."),
 			"did not find the expected message about the duplicated input ID")
 	})
 }
 
-func newBufferLogger() (*logp.Logger, *bytes.Buffer) {
-	buf := &bytes.Buffer{}
-	encoderConfig := zap.NewProductionEncoderConfig()
-	encoder := zapcore.NewJSONEncoder(encoderConfig)
-	writeSyncer := zapcore.AddSync(buf)
-	log := logp.NewLogger("", zap.WrapCore(func(_ zapcore.Core) zapcore.Core {
-		return zapcore.NewCore(encoder, writeSyncer, zapcore.DebugLevel)
-	}))
-	return log, buf
+func observedLogsContain(obs *observer.ObservedLogs, substr string) bool {
+	for _, entry := range obs.All() {
+		if strings.Contains(entry.Message, substr) {
+			return true
+		}
+	}
+	return false
 }
 
 func TestTakeOverConfigUnpack(t *testing.T) {

--- a/filebeat/input/filestream/internal/task/group.go
+++ b/filebeat/input/filestream/internal/task/group.go
@@ -27,6 +27,15 @@ import (
 	"golang.org/x/sync/semaphore"
 )
 
+// semaphoreWeight converts the task limit to a semaphore weight, capping at
+// math.MaxInt64 to satisfy gosec G115.
+func semaphoreWeight(limit uint64) int64 {
+	if limit > math.MaxInt64 {
+		return math.MaxInt64
+	}
+	return int64(limit)
+}
+
 type Group struct {
 	sem *semaphore.Weighted
 	wg  *sync.WaitGroup
@@ -73,7 +82,7 @@ func NewGroup(limit uint64, stopTimeout time.Duration, log Logger, errPrefix str
 
 	var sem *semaphore.Weighted
 	if limit > 0 {
-		sem = semaphore.NewWeighted(int64(min(limit, math.MaxInt64)))
+		sem = semaphore.NewWeighted(semaphoreWeight(limit))
 	}
 
 	return &Group{

--- a/filebeat/input/filestream/internal/task/group_test.go
+++ b/filebeat/input/filestream/internal/task/group_test.go
@@ -45,7 +45,7 @@ type testLogger struct {
 func (tl *testLogger) Errorf(format string, args ...interface{}) {
 	tl.mu.Lock()
 	defer tl.mu.Unlock()
-	tl.b.WriteString(fmt.Sprintf(format, args...))
+	fmt.Fprintf(&tl.b, format, args...)
 	tl.b.WriteString("\n")
 }
 
@@ -56,14 +56,14 @@ func (tl *testLogger) String() string {
 }
 
 func TestNewGroup(t *testing.T) {
-	limit := 10
+	const limit uint64 = 10
 	timeout := time.Second
-	g := NewGroup(uint64(limit), timeout, noopLogger{}, "") //nolint:gosec //limit is 10 no overflow
+	g := NewGroup(limit, timeout, noopLogger{}, "")
 	require.NotNil(t, g, "NewGroup returned a nil group, it cannot be nil")
 
 	require.NotNil(t, g.sem)
 
-	err := g.sem.Acquire(context.Background(), int64(limit-1)) //nolint:gosec //limit is 10 no overflow
+	err := g.sem.Acquire(context.Background(), 9)
 	require.NoError(t, err, "semaphore Acquire failed")
 	assert.True(t, g.sem.TryAcquire(1),
 		"semaphore should have 1 place left, there is none")
@@ -204,13 +204,13 @@ func TestGroup_Go(t *testing.T) {
 
 	t.Run("without limit, all goroutines run", func(t *testing.T) {
 		// 100 <= limit <= 10000
-		limit := rand.IntN(10000-100) + 100
+		limit := uint64(100 + rand.IntN(9900)) //nolint:gosec // G115: test values are small positive ints
 		t.Logf("running %d goroutines", limit)
-		g := NewGroup(uint64(limit), time.Second, noopLogger{}, "")
+		g := NewGroup(limit, time.Second, noopLogger{}, "")
 
 		done := make(chan struct{})
 		var runningCounter atomic.Int64
-		for i := 0; i < limit; i++ {
+		for range limit {
 			err := g.Go(func(context.Context) error {
 				runningCounter.Add(1)
 				defer runningCounter.Add(-1)
@@ -222,7 +222,7 @@ func TestGroup_Go(t *testing.T) {
 		}
 
 		assert.Eventually(t,
-			func() bool { return int64(limit) == runningCounter.Load() },
+			func() bool { return runningCounter.Load() == int64(limit) }, //nolint:gosec // G115: counter only increases to limit
 			1*time.Second,
 			10*time.Millisecond)
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes all golangci-lint warnings reported on the code added/changed in https://github.com/elastic/beats/pull/50963.

## Changes

- **manager_test.go**: Replace `logp.NewLogger` with `logptest.NewTestingLoggerWithObserver` (forbidigo) and add `observedLogsContain` helper
- **group.go**: Add `semaphoreWeight` to safely cap `uint64` limits before converting to `int64` for `semaphore.NewWeighted` (gosec G115)
- **group_test.go**: Use `fmt.Fprintf` instead of `WriteString(fmt.Sprintf(...))` (staticcheck QF1012), use typed constants and targeted nolint comments for test-only conversions
- **fswatch_test.go**: Document that `copyFile` paths are test-controlled (gosec G703)

## Testing

```bash
golangci-lint run --whole-files --new-from-merge-base origin/main ./filebeat/input/filestream/...
go test -race ./filebeat/input/filestream/internal/task/... ./filebeat/input/filestream/internal/input-logfile/... -run 'TestNewGroup|TestGroup_Go|TestInputManager_Create'
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a8bcf8f4-f4f1-4c4c-a170-b6043b7fb002"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a8bcf8f4-f4f1-4c4c-a170-b6043b7fb002"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

