### PR TITLE
Honor enabled flag in reloaded Filebeat inputs

### DIFF
--- a/changelog/fragments/1781712219-honor-enabled-flag-in-filebeat.config.inputs.yaml
+++ b/changelog/fragments/1781712219-honor-enabled-flag-in-filebeat.config.inputs.yaml
@@ -1,0 +1,45 @@
+# REQUIRED
+# Kind can be one of:
+# - breaking-change: a change to previously-documented behavior
+# - deprecation: functionality that is being removed in a later release
+# - bug-fix: fixes a problem in a previous version
+# - enhancement: extends functionality but does not break or fix existing behavior
+# - feature: new functionality
+# - known-issue: problems that we are aware of in a given version
+# - security: impacts on the security of a product or a user’s deployment.
+# - upgrade: important information for someone upgrading from a prior version
+# - other: does not fit into any of the other categories
+kind: bug-fix
+
+# REQUIRED for all kinds
+# Change summary; a 80ish characters long description of the change.
+summary: Honor enabled flag in when reloading inputs.
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# Long description; in case the summary is not enough to describe the change
+# this field accommodate a description without length limits.
+# description:
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# impact:
+
+# REQUIRED for breaking-change, deprecation, known-issue
+# action:
+
+# REQUIRED for all kinds
+# Affected component; usually one of "elastic-agent", "fleet-server", "filebeat", "metricbeat", "auditbeat", "all", etc.
+component: all
+
+# AUTOMATED
+# OPTIONAL to manually add other PR URLs
+# PR URL: A link the PR that added the changeset.
+# If not present is automatically filled by the tooling finding the PR where this changelog fragment has been added.
+# NOTE: the tooling supports backports, so it's able to fill the original PR number instead of the backport PR number.
+# Please provide it if you are adding a fragment for a different PR.
+# pr: https://github.com/owner/repo/1234
+
+# AUTOMATED
+# OPTIONAL to manually add other issue URLs
+# Issue URL; optional; the GitHub issue related to this changeset (either closes or is part of).
+# If not present is automatically filled by the tooling with the issue linked to the PR number.
+# issue: https://github.com/owner/repo/1234

--- a/changelog/fragments/1781712219-honor-enabled-flag-in-filebeat.config.inputs.yaml
+++ b/changelog/fragments/1781712219-honor-enabled-flag-in-filebeat.config.inputs.yaml
@@ -13,7 +13,7 @@ kind: bug-fix
 
 # REQUIRED for all kinds
 # Change summary; a 80ish characters long description of the change.
-summary: Honor enabled flag in when reloading inputs.
+summary: Honor the enabled flag when reloading inputs.
 
 # REQUIRED for breaking-change, deprecation, known-issue
 # Long description; in case the summary is not enough to describe the change

--- a/libbeat/cfgfile/list.go
+++ b/libbeat/cfgfile/list.go
@@ -92,6 +92,11 @@ func (r *RunnerList) Reload(configs []*reload.ConfigWithMeta) error {
 
 	// diff current & desired state, create action lists
 	for _, config := range configs {
+		if !config.Config.Enabled() {
+			r.logger.Debug("Runner config is disabled, skipping")
+			continue
+		}
+
 		hash, err := HashConfig(config.Config)
 		if err != nil {
 			r.logger.Errorf("Unable to hash given config: %s", err)

--- a/libbeat/cfgfile/list_test.go
+++ b/libbeat/cfgfile/list_test.go
@@ -144,6 +144,22 @@ func TestNewConfigs(t *testing.T) {
 	assert.Len(t, list.copyRunnerList(), 3)
 }
 
+func TestReloadSkipsDisabledConfigs(t *testing.T) {
+	factory := &runnerFactory{}
+	logger := logptest.NewTestingLogger(t, "")
+	list := NewRunnerList("", factory, nil, logger)
+
+	err := list.Reload([]*reload.ConfigWithMeta{
+		createConfig(1),
+		createDisabledConfig(2),
+		createConfig(3),
+	})
+
+	require.NoError(t, err, "reloading configs with one disabled config should succeed")
+	assert.Len(t, list.copyRunnerList(), 2, "disabled configs should not start runners")
+	assert.Len(t, factory.runners, 2, "disabled configs should not be passed to the runner factory")
+}
+
 func TestReloadSameConfigs(t *testing.T) {
 	factory := &runnerFactory{}
 	logger := logptest.NewTestingLogger(t, "")
@@ -217,6 +233,33 @@ func TestReloadStopConfigs(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.Len(t, list.copyRunnerList(), 2)
+}
+
+func TestReloadStopsDisabledConfigs(t *testing.T) {
+	factory := &runnerFactory{}
+	logger := logptest.NewTestingLogger(t, "")
+	list := NewRunnerList("", factory, nil, logger)
+
+	err := list.Reload([]*reload.ConfigWithMeta{
+		createConfig(1),
+		createConfig(2),
+	})
+	require.NoError(t, err, "initial reload should start enabled configs")
+	assert.Len(t, list.copyRunnerList(), 2, "initial reload should start both enabled configs")
+
+	hash, err := HashConfig(createConfig(2).Config)
+	require.NoError(t, err, "hashing enabled config should succeed")
+	startedRunner := list.copyRunnerList()[hash]
+	require.NotNil(t, startedRunner, "expected runner for config before disabling it")
+
+	err = list.Reload([]*reload.ConfigWithMeta{
+		createConfig(1),
+		createDisabledConfig(2),
+	})
+
+	require.NoError(t, err, "reloading with disabled config should succeed")
+	assert.Len(t, list.copyRunnerList(), 1, "disabled configs should be removed from the running set")
+	assert.True(t, startedRunner.(*runner).stopped, "runner should stop when its config is disabled") //nolint:errcheck //false positive
 }
 
 func TestReloadStartStopConfigs(t *testing.T) {
@@ -342,4 +385,10 @@ func createConfig(id int64) *reload.ConfigWithMeta {
 	return &reload.ConfigWithMeta{
 		Config: c,
 	}
+}
+
+func createDisabledConfig(id int64) *reload.ConfigWithMeta {
+	cfg := createConfig(id)
+	_ = cfg.Config.SetBool("enabled", -1, false)
+	return cfg
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Proposed commit message

Honor enabled flag in reloaded Filebeat inputs

Skip disabled configs when building the dynamic runner desired state so dynamic runner configs with `enabled: false` are not started and existing runners are stopped when their config is disabled. This fixes `filebeat.config.inputs` honoring the per-input `enabled` flag and makes the shared `cfgfile.RunnerList` runtime behavior consistent with the existing reload validation path, which already skipped disabled configs.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works. Where relevant, I have used the [`stresstest.sh`](https://github.com/elastic/beats/blob/main/script/stresstest.sh) script to run them under stress conditions and race detector to verify their stability.
- [x] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent-changelog-tool/blob/main/docs/usage.md).

## Disruptive User Impact

Low risk, but the change is in the shared `libbeat/cfgfile.RunnerList` reload path rather than a Filebeat-only call site. Any caller using `RunnerList.Reload` will now treat a top-level `enabled: false` config as disabled and omit it from the desired runner set. That means such configs will not start new runners, and any already-running matching runner will be stopped on reload.

Known affected shared users include file-based dynamic reload/load, Filebeat managed inputs/modules, Metricbeat managed modules, Packetbeat's reloader wrapper, and autodiscover. Configs with `enabled` omitted or `enabled: true` keep the existing behavior. Heartbeat uses its own `HBRunnerList` and is not affected by this PR.

This aligns runtime reload behavior with the existing `Reloader.Check` validation behavior, which already skipped disabled configs.

## How to test this PR locally

```bash
go test ./libbeat/cfgfile
go test -race ./libbeat/cfgfile
```

## Related issues

- Closes https://github.com/elastic/beats/issues/17638

## Use cases

Users can place multiple inputs under `filebeat.config.inputs` and set `enabled: false` on individual input configs to prevent them from running. If a previously running dynamic input is reloaded with `enabled: false`, it is removed from the desired runner set and stopped.

Because the fix is applied in `RunnerList.Reload`, the same top-level `enabled: false` semantics also apply to other shared dynamic runner users.

## Screenshots

N/A

## Logs

```text
ok  	github.com/elastic/beats/v7/libbeat/cfgfile	2.007s
ok  	github.com/elastic/beats/v7/libbeat/cfgfile	3.019s
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1a7b26b8-481f-407b-b487-a114db8e00a4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1a7b26b8-481f-407b-b487-a114db8e00a4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

